### PR TITLE
fix(NotFoundJson): Changed `string` to `String`

### DIFF
--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -34,5 +34,5 @@ pub struct TooManyRequestsJson {
 #[derive(Serialize, Deserialize)]
 // JSON returned along with HTTP 404 Not Found.
 pub struct NotFoundJson {
-    pub message: string,
+    pub message: String,
 }


### PR DESCRIPTION
This Pr fixes of capitalization error