### PR TITLE
Return JSON instead of raw text for /auth/{id} to be consistent with other routes.

### DIFF
--- a/src/request_json/guilds.rs
+++ b/src/request_json/guilds.rs
@@ -18,5 +18,5 @@ pub struct GetGuildUrlParams {
     /// Return the list of members in the response?
     ///
     /// Defaults to `false` if not specified.
-    pub members: Option<bool>
+    pub members: Option<bool>,
 }

--- a/src/request_json/mod.rs
+++ b/src/request_json/mod.rs
@@ -1,9 +1,9 @@
-mod guilds;
-mod users;
 mod channels;
+mod guilds;
 mod messages;
+mod users;
 
-pub use guilds::*;
-pub use users::*;
 pub use channels::*;
+pub use guilds::*;
 pub use messages::*;
+pub use users::*;

--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -2,5 +2,4 @@
 pub struct AuthResponse {
     /// The authorization token
     pub token: String,
-
 }

--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -1,0 +1,6 @@
+#[derive(Serialize, Deserialize)]
+pub struct AuthResponse {
+    /// The authorization token
+    pub token: String,
+
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod channel;
 mod errors;
 mod guild;
@@ -6,6 +7,7 @@ mod message;
 mod model_type;
 mod user;
 
+pub use auth::AuthResponse;
 pub use channel::Channel;
 pub use errors::*;
 pub use guild::Guild;


### PR DESCRIPTION
See title