### PR TITLE
Add guild flags

### DIFF
--- a/src/types/guild.rs
+++ b/src/types/guild.rs
@@ -28,6 +28,11 @@ pub struct Guild {
     ///
     /// Not sent at times to reduce bandwidth usage
     pub members: Option<Vec<Member>>,
+
+    /// Guild flags
+    ///
+    /// Bitmask of guild info
+    pub flags: i64,
 }
 
 bitflags! {


### PR DESCRIPTION
This PR aims to add necessary guild flags.

Such flags include:
- `VERIFIED_GUILD` - Used to show whether the owner of a guild has been verified to be the real owner (for content creators, etc)
- `VERIFIED_SCAM` - Used to show that the guild has been reported and confirmed to be promoting scams or practices that harm users financially or physically.