### PR TITLE
Add channel object

### DIFF
--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1,5 +1,4 @@
-use crate::types::Embed;
-use crate::types::User;
+use crate::types::{Embed, User, Channel};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 
@@ -16,7 +15,7 @@ pub struct Message {
     pub content: Option<String>,
 
     /// The channel this message is in
-    pub channel_id: u128,
+    pub channel_id: Option<Channel>,
 
     /// The author ID
     ///

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -17,6 +17,9 @@ pub struct Message {
     /// The channel this message is in
     pub channel: Option<Channel>,
 
+    /// The ID of the channel this message is in
+    pub channel_id: u128,
+
     /// The author ID
     ///
     /// 128 bit unsigned integer
@@ -54,7 +57,8 @@ impl Serialize for Message {
         self_ser.serialize_field("content", &self.content)?;
 
         self_ser.serialize_field("channel", &self.channel)?;
-        self_ser.serialize_field("channel_id_string", &self.channel.id.to_string())?;
+        self_ser.serialize_field("channel_id", &self.channel_id)?;
+        self_ser.serialize_field("channel_id_string", &self.channel_id.to_string())?;
 
         self_ser.serialize_field("author_id", &self.author_id)?;
         self_ser.serialize_field("author_id_string", &self.author_id.to_string())?;

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1,4 +1,4 @@
-use crate::types::{Embed, User, Channel};
+use crate::types::{Channel, Embed, User};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -15,7 +15,7 @@ pub struct Message {
     pub content: Option<String>,
 
     /// The channel this message is in
-    pub channel_id: Option<Channel>,
+    pub channel: Option<Channel>,
 
     /// The author ID
     ///

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -53,8 +53,8 @@ impl Serialize for Message {
 
         self_ser.serialize_field("content", &self.content)?;
 
-        self_ser.serialize_field("channel_id", &self.channel_id)?;
-        self_ser.serialize_field("channel_id_string", &self.channel_id.to_string())?;
+        self_ser.serialize_field("channel", &self.channel)?;
+        self_ser.serialize_field("channel_id_string", &self.channel.id.to_string())?;
 
         self_ser.serialize_field("author_id", &self.author_id)?;
         self_ser.serialize_field("author_id_string", &self.author_id.to_string())?;


### PR DESCRIPTION
This PR aims to add the channel object to where messages are returned.

In conjunction with FerrisChat/Server:develop@923da280a7a12d50e7464b2bffee9394c5a3c79e